### PR TITLE
Switch to private images and subnets

### DIFF
--- a/iac/base-infra-cfn.yaml
+++ b/iac/base-infra-cfn.yaml
@@ -3,11 +3,6 @@ Description: >
   This template provisions the infrastructure and deploys the Fargate services for use with the YELB sample application and Service Connect migration blog post.
 
 Parameters:
-  StackName:
-    Type: String
-    Default: yelb-serviceconnect
-    Description: The name of the parent Fargate networking stack you created. Necessary to locate and reference resources created by said stack.
-
   EnvironmentName:
     Type: String
     Default: "ecs"
@@ -52,6 +47,11 @@ Parameters:
     Type: String
     Default: "yelb-db"
     Description: ECS Yelb Db Service name
+
+  CentralLogGroup:
+    Type: String
+    Default: "ecs/serviceconnectdemo"
+    Description: CloudWatch Log Group Name
 
 Mappings:
   # Hard values for the subnet masks. These masks define
@@ -300,20 +300,26 @@ Resources:
       GroupName: yelb-appserver-sg
       VpcId: !Ref VPC
       SecurityGroupIngress:
+        - SourceSecurityGroupId: !Ref YelbAppServerAlbSecurityGroup
+          IpProtocol: tcp
+          ToPort: 4567
+          FromPort: 4567
         - SourceSecurityGroupId: !Ref YelbUiSecurityGroup
           IpProtocol: tcp
           ToPort: 4567
           FromPort: 4567
 
-  YelbAppServerSecurityGroupIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    DependsOn: YelbAppServerSecurityGroup
+  YelbAppServerAlbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupId: !Ref YelbAppServerSecurityGroup
-      IpProtocol: tcp
-      FromPort: 4567
-      ToPort: 4567
-      SourceSecurityGroupId: !Ref YelbAppServerSecurityGroup
+      GroupDescription: yelb-appserver ALB security group
+      GroupName: yelb-appserver-alb-sg
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - SourceSecurityGroupId: !Ref YelbUiSecurityGroup
+          IpProtocol: tcp
+          ToPort: 4567
+          FromPort: 4567
 
   YelbUiSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -403,6 +409,9 @@ Resources:
           Value: '20'
       TargetType: ip
       IpAddressType: ipv4
+      HealthCheckIntervalSeconds: 10  # Default is 30
+      HealthyThresholdCount: 2        # Default is 5
+      UnhealthyThresholdCount: 2      # Default is 2
 
   EcsLbListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
@@ -422,7 +431,7 @@ Resources:
       Name: serviceconnect-appserver
       Scheme: internal
       SecurityGroups:
-        - !Ref YelbAppServerSecurityGroup
+        - !Ref YelbAppServerAlbSecurityGroup
       Subnets:
         - !Ref PrivateSubnet1
         - !Ref PrivateSubnet2
@@ -441,6 +450,9 @@ Resources:
       TargetType: ip
       IpAddressType: ipv4
       HealthCheckPath: "/api/getvotes"
+      HealthCheckIntervalSeconds: 10  # Default is 30
+      HealthyThresholdCount: 2        # Default is 5
+      UnhealthyThresholdCount: 2      # Default is 2
 
   EcsInternalListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
@@ -467,59 +479,8 @@ Resources:
         DNSName: !GetAtt EcsInternalLoadBalancer.DNSName
         HostedZoneId: !GetAtt EcsInternalLoadBalancer.CanonicalHostedZoneID
       HostedZoneId: !Ref PrivateHostedZone
-      Name: !Join
-        - ""
-        - - "yelb-appserver."
-          - !Ref "HostedZoneDomainName"
+      Name: !Sub "${YelbAppserverServiceName}.${HostedZoneDomainName}"
       Type: A
-      Region: !Sub "${AWS::Region}"
-      SetIdentifier: !Join
-        - ""
-        - - "yelb-appserver."
-          - !Ref "HostedZoneDomainName"
-
-  # IAM Rules
-  ECSSCTaskPolicy:
-    Type: "AWS::IAM::ManagedPolicy"
-    Properties:
-      Description: Managed policy for the ECS Task roles
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              # Allow the ECS Tasks to download images from ECR
-              - "ecr:GetAuthorizationToken"
-              - "ecr:BatchCheckLayerAvailability"
-              - "ecr:GetDownloadUrlForLayer"
-              - "ecr:BatchGetImage"
-              # Allow the ECS tasks to upload logs to CloudWatch
-              - "logs:CreateLogStream"
-              - "logs:PutLogEvents"
-            Resource: "*"
-
-  YelbECSTaskRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - "ecs.amazonaws.com"
-                - "ecs-tasks.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
-          - Effect: "Allow"
-            Principal:
-              AWS:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - "sts:AssumeRole"
-      Path: "/"
-      ManagedPolicyArns:
-        - !Ref ECSSCTaskPolicy
 
   YelbECSTaskExecutionRole:
     Type: AWS::IAM::Role
@@ -531,31 +492,8 @@ Resources:
               Service: [ecs-tasks.amazonaws.com]
             Action: ["sts:AssumeRole"]
       Path: /
-      Policies:
-        - PolicyName: AmazonECSTaskExecutionRolePolicy
-          PolicyDocument:
-            Statement:
-              - Effect: Allow
-                Action:
-                  # Allow the ECS Tasks to download images from ECR
-                  - "ecr:GetAuthorizationToken"
-                  - "ecr:BatchCheckLayerAvailability"
-                  - "ecr:GetDownloadUrlForLayer"
-                  - "ecr:BatchGetImage"
-
-                  # Allow the ECS tasks to upload logs to CloudWatch
-                  - "logs:CreateLogStream"
-                  - "logs:PutLogEvents"
-
-                  # Allow the ECS tasks to register into the target group
-                  - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
-                  - "elasticloadbalancing:Describe*"
-                  - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
-                  - "elasticloadbalancing:DeregisterTargets"
-                  - "elasticloadbalancing:DescribeTargetGroups"
-                  - "elasticloadbalancing:DescribeTargetHealth"
-                  - "elasticloadbalancing:RegisterTargets"
-                Resource: "*"
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 
   # Yelb DB Service and Task Definition
   ServiceYelbDb:
@@ -564,19 +502,15 @@ Resources:
       ServiceName: !Ref YelbDbServiceName
       LaunchType: FARGATE
       Cluster: !Ref ECSCluster
-      PlatformVersion: LATEST
-      PropagateTags: SERVICE
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 0
-      EnableECSManagedTags: true
-      EnableExecuteCommand: true
       DesiredCount: 1
       TaskDefinition: !Ref "TaskDefinitionYelbDb"
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
-          Subnets: [!Ref "PublicSubnet1", !Ref "PublicSubnet2"]
+          AssignPublicIp: DISABLED
+          Subnets: [!Ref "PrivateSubnet1", !Ref "PrivateSubnet2"]
           SecurityGroups: [!Ref "YelbDbSecurityGroup"]
       ServiceRegistries:
         - RegistryArn: !GetAtt YelbDbServiceDiscoveryEntry.Arn
@@ -590,11 +524,10 @@ Resources:
       Memory: "512"
       RequiresCompatibilities:
         - FARGATE
-      TaskRoleArn: !Ref "YelbECSTaskRole"
       ExecutionRoleArn: !Ref "YelbECSTaskExecutionRole"
       ContainerDefinitions:
         - Name: yelb-db
-          Image: public.ecr.aws/j7e2a1k3/yelb-sc-db:0.5
+          Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/yelb-db:latest
           Cpu: 100
           Essential: true
           PortMappings:
@@ -604,7 +537,7 @@ Resources:
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-group: ecs/serviceconnectdemo
+              awslogs-group: !Ref CentralLogGroup
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "yelb"
 
@@ -615,19 +548,15 @@ Resources:
       ServiceName: !Ref YelbRedisServiceName
       LaunchType: FARGATE
       Cluster: !Ref ECSCluster
-      PlatformVersion: LATEST
-      PropagateTags: SERVICE
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 0
-      EnableECSManagedTags: true
-      EnableExecuteCommand: true
       DesiredCount: 1
       TaskDefinition: !Ref "TaskDefinitionRedisServer"
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
-          Subnets: [!Ref "PublicSubnet1", !Ref "PublicSubnet2"]
+          AssignPublicIp: DISABLED
+          Subnets: [!Ref "PrivateSubnet1", !Ref "PrivateSubnet2"]
           SecurityGroups: [!Ref "YelbRedisSecurityGroup"]
       ServiceRegistries:
         - RegistryArn: !GetAtt YelbRedisServiceDiscoveryEntry.Arn
@@ -641,11 +570,10 @@ Resources:
       Memory: "512"
       RequiresCompatibilities:
         - FARGATE
-      TaskRoleArn: !Ref "YelbECSTaskRole"
       ExecutionRoleArn: !Ref "YelbECSTaskExecutionRole"
       ContainerDefinitions:
         - Name: redis-server
-          Image: public.ecr.aws/j7e2a1k3/redis-sc:4.0.2
+          Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/redis:latest
           Cpu: 100
           Essential: true
           PortMappings:
@@ -655,7 +583,7 @@ Resources:
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-group: ecs/serviceconnectdemo
+              awslogs-group: !Ref CentralLogGroup
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "yelb"
 
@@ -670,19 +598,18 @@ Resources:
       LaunchType: FARGATE
       ServiceName: !Ref YelbAppserverServiceName
       Cluster: !Ref ECSCluster
-      PlatformVersion: LATEST
-      PropagateTags: SERVICE
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
-      EnableECSManagedTags: true
-      EnableExecuteCommand: true
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
       DesiredCount: 3
       TaskDefinition: !Ref "TaskDefinitionYelbAppserver"
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
-          Subnets: [!Ref "PublicSubnet1", !Ref "PublicSubnet2"]
+          AssignPublicIp: DISABLED
+          Subnets: [!Ref "PrivateSubnet1", !Ref "PrivateSubnet2"]
           SecurityGroups: [!Ref "YelbAppServerSecurityGroup"]
       LoadBalancers:
         - TargetGroupArn: !Ref EcsInternalTargetGroup
@@ -698,12 +625,10 @@ Resources:
       Memory: "512"
       RequiresCompatibilities:
         - FARGATE
-      TaskRoleArn: !Ref "YelbECSTaskRole"
       ExecutionRoleArn: !Ref "YelbECSTaskExecutionRole"
       ContainerDefinitions:
         - Name: yelb-appserver
-          Image: public.ecr.aws/j7e2a1k3/yelb-sc-appserver:latest
-          Cpu: 100
+          Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/yelb-appserver:latest
           Essential: true
           PortMappings:
             - Name: yelb-appserver
@@ -713,18 +638,16 @@ Resources:
           Environment:
             - Name: APP_PORT
               Value: "4567"
-            - Name: YELB_DB_SERVER
-              Value: yelb-db.yelb.cloudmap.internal
-            - Name: YELB_DB_SERVER_PORT
-              Value: "5432"
-            - Name: YELB_REDIS_SERVER
-              Value: yelb-redis.yelb.cloudmap.internal
-            - Name: YELB_REDIS_SERVER_PORT
-              Value: "6379"
+            - Name: RACK_ENV
+              Value: "custom"
+            - Name: YELB_DB_SERVER_ENDPOINT
+              Value: !Sub "${YelbDbServiceName}.${YelbCloudMapDomain}"
+            - Name: REDIS_SERVER_ENDPOINT
+              Value: !Sub "${YelbRedisServiceName}.${YelbCloudMapDomain}"
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-group: ecs/serviceconnectdemo
+              awslogs-group: !Ref CentralLogGroup
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "yelb"
 
@@ -739,19 +662,18 @@ Resources:
       LaunchType: FARGATE
       ServiceName: !Ref YelbUiServiceName
       Cluster: !Ref ECSCluster
-      PlatformVersion: LATEST
-      PropagateTags: SERVICE
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 50
-      EnableECSManagedTags: true
-      EnableExecuteCommand: true
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
       DesiredCount: 3
       TaskDefinition: !Ref "TaskDefinitionYelbUi"
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
-          Subnets: [!Ref "PublicSubnet1", !Ref "PublicSubnet2"]
+          AssignPublicIp: DISABLED
+          Subnets: [!Ref "PrivateSubnet1", !Ref "PrivateSubnet2"]
           SecurityGroups: [!Ref "YelbUiSecurityGroup"]
       LoadBalancers:
         - ContainerName: "yelb-ui"
@@ -769,27 +691,22 @@ Resources:
       Memory: "512"
       RequiresCompatibilities:
         - FARGATE
-      TaskRoleArn: !Ref "YelbECSTaskRole"
       ExecutionRoleArn: !Ref "YelbECSTaskExecutionRole"
       ContainerDefinitions:
         - Name: yelb-ui
-          Image: public.ecr.aws/j7e2a1k3/yelb-sc-ui:latest
-          Cpu: 100
-          Essential: true
+          Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/yelb-ui:latest
           PortMappings:
             - Name: yelb-ui
               ContainerPort: 80
               Protocol: tcp
               AppProtocol: http
           Environment:
-            - Name: APP_SERVER
-              Value: yelb-appserver.yelb.lb.internal
-            - Name: APP_SERVER_PORT
-              Value: "4567"
+            - Name: YELB_APPSERVER_ENDPOINT
+              Value: !Sub "http://${YelbAppserverServiceName}.${HostedZoneDomainName}:4567"
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-group: ecs/serviceconnectdemo
+              awslogs-group: !Ref CentralLogGroup
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "yelb"
 
@@ -797,8 +714,8 @@ Resources:
   CloudWatchLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: "ecs/serviceconnectdemo"
-      RetentionInDays: 90
+      LogGroupName: !Ref CentralLogGroup
+      RetentionInDays: 7
 
 Outputs:
   VPC:

--- a/iac/ecr-images.yaml
+++ b/iac/ecr-images.yaml
@@ -1,0 +1,36 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  This template provides the ECR repositories that are used by the yelb
+  application and is a prerequisite to the ECS resources
+
+Resources:
+  # ECR Repositories
+  YelbAppServerRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: yelb-appserver
+      EmptyOnDelete: true
+
+  YelbUiRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: yelb-ui
+      EmptyOnDelete: true
+
+  YelbDbRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: yelb-db
+      EmptyOnDelete: true
+
+  RedisRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: redis
+      EmptyOnDelete: true
+
+  LoadTestRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: hey-loadtest
+      EmptyOnDelete: true

--- a/iac/load-test-cfn.yaml
+++ b/iac/load-test-cfn.yaml
@@ -1,53 +1,12 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: Deploy a Fargate task that uses hey to generate parallel concurrent traffic
+Description: >
+  Deploy a Fargate task that uses hey to generate parallel concurrent traffic
 Parameters:
-  EnvironmentName:
-    Type: String
-    Default: "ecs"
-    Description: An environment name that will be prefixed to resource names
   URL:
     Type: String
     Description: Url for load test
 
 Resources:
-  # IAM Rules
-  ECSTaskPolicy:
-    Type: "AWS::IAM::ManagedPolicy"
-    Properties:
-      Description: Managed policy for the ECS Task roles
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              # Allow the ECS tasks to upload logs to CloudWatch
-              - "logs:CreateLogStream"
-              - "logs:PutLogEvents"
-            Resource: "*"
-
-  # ECS Loadtest Task Role
-  ECSLoadTaskRole:
-    Type: "AWS::IAM::Role"
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - "ecs.amazonaws.com"
-                - "ecs-tasks.amazonaws.com"
-            Action: "sts:AssumeRole"
-          - Effect: "Allow"
-            Principal:
-              AWS:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - "sts:AssumeRole"
-      Path: "/"
-      ManagedPolicyArns:
-        - !Ref ECSTaskPolicy
-
   # ECS Loadtest Task Execution Role
   ECSLoadTaskExecutionRole:
     Type: AWS::IAM::Role
@@ -59,16 +18,8 @@ Resources:
               Service: [ecs-tasks.amazonaws.com]
             Action: ["sts:AssumeRole"]
       Path: /
-      Policies:
-        - PolicyName: AmazonECSTaskExecutionRolePolicy
-          PolicyDocument:
-            Statement:
-              - Effect: Allow
-                Action:
-                  # Allow the ECS tasks to upload logs to CloudWatch
-                  - "logs:CreateLogStream"
-                  - "logs:PutLogEvents"
-                Resource: "*"
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 
   # Fargate Task
   TaskDefinition:
@@ -80,12 +31,10 @@ Resources:
       Memory: "512"
       RequiresCompatibilities:
         - FARGATE
-      TaskRoleArn: !Ref "ECSLoadTaskRole"
       ExecutionRoleArn: !Ref "ECSLoadTaskExecutionRole"
       ContainerDefinitions:
         - Name: yelb-loadtest
-          Image: public.ecr.aws/j7e2a1k3/hey-loadtest:1.0
-          Cpu: 100
+          Image: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/hey-loadtest:latest
           Command:
             - -c
             - 100
@@ -99,4 +48,4 @@ Resources:
             Options:
               awslogs-group: ecs/serviceconnectdemo
               awslogs-region: !Ref "AWS::Region"
-              awslogs-stream-prefix: "yelb"
+              awslogs-stream-prefix: "loadtest"

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -7,7 +7,7 @@ set -e
 #  AWS CLI Version: 2.9.2 or higher
 
 # source functions and arguments script
-# must use . instead of 'source' for linux runs to support /bin/dash instad of /bin/bash
+# must use . instead of 'source' for linux runs to support /bin/dash instead of /bin/bash
 . ./scripts/env.sh
 
 # Get deployed region
@@ -34,6 +34,10 @@ deleteCfnStack 'hey-loadtest'
 linebreak
 
 deleteCfnStack 'yelb-serviceconnect'
+
+linebreak
+
+deleteCfnStack 'yelb-ecr-repositories'
 
 # Final cleanup of tmp files and restore any sc-update files to original state
 rm -rf .region

--- a/scripts/generate-traffic.sh
+++ b/scripts/generate-traffic.sh
@@ -1,11 +1,11 @@
-# !/bin/bash
+#!/bin/bash
 set -e
 
 # Requirements:
 #  AWS CLI Version: 2.9.2 or higher
 
 # source functions and arguments script
-# must use . instead of 'source' for linux runs to support /bin/dash instad of /bin/bash
+# must use . instead of 'source' for linux runs to support /bin/dash instead of /bin/bash
 . ./scripts/env.sh
 
 # Get deployed region
@@ -29,7 +29,7 @@ aws --region "${AWS_DEFAULT_REGION}" \
     --template-file "${SPATH}/iac/load-test-cfn.yaml" \
     --parameter-overrides \
     EnvironmentName="${ENVIRONMENT_NAME}" \
-    URL="${appEndpoint}/api/getvotes"   
+    URL="${appEndpoint}/api/getvotes"
 
 linebreak
 

--- a/scripts/remove-service-connect.sh
+++ b/scripts/remove-service-connect.sh
@@ -1,8 +1,8 @@
-# !/bin/bash
+#!/bin/bash
 set -e
 
 # source functions and arguments script
-# must use . instead of 'source' for linux runs to support /bin/dash instad of /bin/bash
+# must use . instead of 'source' for linux runs to support /bin/dash instead of /bin/bash
 . ./scripts/env.sh
 
 # Get outputs from CFN Setup
@@ -13,7 +13,7 @@ if [[ $serviceId ]]; then
     echo "Draining AWS Cloud Map and Amazon ECS Service Connect instances..."
     drainServiceConnect
     while [ -n "$serviceId" ]; do
-        serviceId=$(getServiceId) && sleep 15; 
+        serviceId=$(getServiceId) && sleep 15;
     done
     echo 'Amazon ECS Service Connect Drain Complete!'
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,7 +8,7 @@ set -e
 #  AWS CLI Version: 2.9.2 or higher
 
 # source functions and exports
-# must use . instead of 'source' for linux runs to support /bin/dash instad of /bin/bash
+# must use . instead of 'source' for linux runs to support /bin/dash instead of /bin/bash
 . ./scripts/env.sh
 
 # Arguments
@@ -28,8 +28,84 @@ ENVIRONMENT_NAME=${ENVIRONMENT_NAME:-ecs}
 CLUSTER_NAME=$4
 CLUSTER_NAME=${CLUSTER_NAME:-yelb-cluster}
 
+# Get AWS Account ID and set it as environment variable
+if [ -z "${AWS_ACCOUNT_ID}" ]; then
+    echo "Getting AWS Account ID..."
+    AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text) || {
+        echo "Failed to get AWS Account ID"
+        exit 1
+    }
+fi
+
+# Create the ECR repositories
+echo "Creating ECR repositories"
+aws --profile "${AWS_PROFILE}" \
+    --region "${AWS_DEFAULT_REGION}" \
+    cloudformation deploy \
+    --stack-name "yelb-ecr-repositories" \
+    --template-file "${SPATH}/iac/ecr-images.yaml" \
+
+# Check for container runtime
+if command -v docker &> /dev/null; then
+    echo "Using Docker as container runtime"
+    CONTAINER_CMD="docker"
+elif command -v finch &> /dev/null; then
+    echo "Using Finch as container runtime"
+    CONTAINER_CMD="finch"
+elif command -v podman &> /dev/null; then
+    echo "Using Podman as container runtime"
+    CONTAINER_CMD="podman"
+elif command -v nerdctl &> /dev/null; then
+    echo "Using Nerdctl as container runtime"
+    CONTAINER_CMD="nerdctl"
+else
+    echo "No container runtime found. Please install Docker, Finch, Podman, or Nerdctl"
+    exit 1
+fi
+
+# Login to ECR (required before pushing)
+echo "Logging into Amazon ECR"
+aws ecr get-login-password --region $AWS_DEFAULT_REGION | $CONTAINER_CMD login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
+
+declare -A images=(
+    ["mreferre/yelb-db:0.6"]="yelb-db"
+    ["mreferre/yelb-ui:0.10"]="yelb-ui"
+    ["mreferre/yelb-appserver:0.7"]="yelb-appserver"
+    ["public.ecr.aws/docker/library/redis:5.0.14"]="redis"
+    ["jldeen/hey-loadtest:1.0"]="hey-loadtest"
+)
+
+# Loop through the images
+echo "Download the container images"
+for source_image in "${!images[@]}"; do
+    repo_name="${images[$source_image]}"
+    target_image="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$repo_name:latest"
+
+    echo "Processing $source_image -> $target_image"
+
+    # Pull the image
+    echo "Pulling $source_image..."
+    $CONTAINER_CMD pull "$source_image"
+
+    # Tag the image
+    echo "Tagging as $target_image..."
+    $CONTAINER_CMD tag "$source_image" "$target_image"
+
+    # Push to ECR
+    echo "Pushing to ECR..."
+    $CONTAINER_CMD push "$target_image"
+
+    echo "Completed processing $repo_name"
+    echo "----------------------------------------"
+done
+echo "All images have been processed"
+
+linebreak
+
 # Deploy the infrastructure, service definitions, and task definitions WITHOUT ECS Service Connect
-aws --profile "${AWS_PROFILE}" --region "${AWS_DEFAULT_REGION}" \
+echo "Creating the Base Infrastructure"
+aws --profile "${AWS_PROFILE}" \
+    --region "${AWS_DEFAULT_REGION}" \
     cloudformation deploy \
     --stack-name "yelb-serviceconnect" \
     --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \

--- a/scripts/use-service-connect.sh
+++ b/scripts/use-service-connect.sh
@@ -1,11 +1,11 @@
-# !/bin/bash
+#!/bin/bash
 set -e
 
 # Requirements:
 #  AWS CLI Version: 2.9.2 or higher
 
 # source functions and arguments script
-# must use . instead of 'source' for linux runs to support /bin/dash instad of /bin/bash
+# must use . instead of 'source' for linux runs to support /bin/dash instead of /bin/bash
 . ./scripts/env.sh
 
 # Get deployed region
@@ -53,6 +53,7 @@ aws ecs update-service \
     --region "${AWS_DEFAULT_REGION}" \
     --cluster $ecsName \
     --service $SVC_APPSERVER \
+    --load-balancers "[]" \
     --service-connect-configuration file://sc-update/svc-appserver.json >/dev/null
 
 echo "Updating $SVC_UI..."


### PR DESCRIPTION
*Description of changes:*

- Migrate to the end user hosting the containers images within ECR. As part of the `setup.sh` script, it now creates ECR repositories in CloudFormation and then uses a local container runtime to pull / push the images from an upstream source. 
  - This fixes (https://github.com/aws-samples/ecs-service-connect-yelb-sample-app/issues/13.
- Migrate the ECS Tasks to Private Subnets rather then Public Subnets. 
  - This fixes https://github.com/aws-samples/ecs-service-connect-yelb-sample-app/issues/9
- A number of smaller changes:
  - Removed unnecessary ECS Task and ECS Execution IAM policies.
  - Removed unused CloudFormation Parameters.
  - Moved Internal LB onto it’s own Security Group.
  - Fixed a few typos in this bash scripts..


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
